### PR TITLE
Add support for PacketIn/PacketOut and Geneve header in OpenFlow cont…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cenkalti/rpc2 v0.0.0-20180727162946-9642ea02d0aa // indirect
 	github.com/containernetworking/cni v0.7.1
 	github.com/containernetworking/plugins v0.8.2-0.20190724153215-ded2f1757770
-	github.com/contiv/libOpenflow v0.0.0-20200319171453-882ba6d92cbc
+	github.com/contiv/libOpenflow v0.0.0-20200424005919-3a6722c98962
 	github.com/contiv/ofnet v0.0.0-00010101000000-000000000000
 	github.com/coreos/go-iptables v0.4.1
 	github.com/davecgh/go-spew v1.1.1
@@ -52,7 +52,7 @@ require (
 )
 
 replace (
-	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20200326015539-5862ec3fa686
+	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20200426030717-ee308d77ef01
 	// Octant is renamed from vmware/octant to vmware-tanzu/octant since v0.9.0.
 	// However, Octant v0.9.0 K8s API is not compatible with Antrea K8s API version.
 	// Furthermore, octant v0.8 and v0.9 do not check-in some generated code required for testing

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/containernetworking/cni v0.7.1 h1:fE3r16wpSEyaqY4Z4oFrLMmIGfBYIKpPrHK
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.2-0.20190724153215-ded2f1757770 h1:AuFzUXPFhLlTfxhHMGdCIr7wZOQ0J0dEZLoffU0KfRM=
 github.com/containernetworking/plugins v0.8.2-0.20190724153215-ded2f1757770/go.mod h1:AlmXjbiLJBqvZ4vxkWAqjx1CKHVEoQf0/Ugrvc6Cv70=
-github.com/contiv/libOpenflow v0.0.0-20200319171453-882ba6d92cbc h1:xCk8SOFX7a5svlcuRKzJ4XqekAk+CpKQNWqPY/UXX9k=
-github.com/contiv/libOpenflow v0.0.0-20200319171453-882ba6d92cbc/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
+github.com/contiv/libOpenflow v0.0.0-20200424005919-3a6722c98962 h1:J5j3JV+Z9/Hg0ufQwk37uk8ZCJ+YUxEFxekBpIMI/JE=
+github.com/contiv/libOpenflow v0.0.0-20200424005919-3a6722c98962/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358 h1:AiA9SKyNXulsU7aAnyka3UFHYOIH00A9HvdIRnDXlg0=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358/go.mod h1:+qKEHaNVPj+wrn5st7TEFH9wcUWCJq5ZBvVKPQwzAeg=
 github.com/coreos/bbolt v1.3.1-coreos.6 h1:uTXKg9gY70s9jMAKdfljFQcuh4e/BXOM+V+d00KFj3A=
@@ -337,8 +337,8 @@ github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYp
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/wenyingd/ofnet v0.0.0-20200326015539-5862ec3fa686 h1:a6OxcU1iYvnisaTUHK4C1jqbawN+IFwtNF9DgeKt4dA=
-github.com/wenyingd/ofnet v0.0.0-20200326015539-5862ec3fa686/go.mod h1:kPb/y9p2i14dW8xNvRnVo2D+xhcthRQZdii5ltI0fjI=
+github.com/wenyingd/ofnet v0.0.0-20200426030717-ee308d77ef01 h1:D2nFotGM2CHzN5Qqy+o2dEJIvyNMp9tzlT88z1y0maM=
+github.com/wenyingd/ofnet v0.0.0-20200426030717-ee308d77ef01/go.mod h1:+g6SfqhTVqeGEmUJ0l4WtCgsL4dflTUJE4k+TPCKqXo=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 h1:MPPkRncZLN9Kh4MEFmbnK4h3BD7AUmskWv2+EeZJCCs=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -254,7 +254,7 @@ func (ctx *conjMatchFlowContext) createOrUpdateConjunctiveMatchFlow(actions []*c
 	}
 
 	// Modify the existing Openflow entry and reset the actions.
-	flowBuilder := ctx.flow.CopyToBuilder()
+	flowBuilder := ctx.flow.CopyToBuilder(0)
 	for _, act := range actions {
 		flowBuilder.Action().Conjunction(act.conjID, act.clauseID, act.nClause)
 	}

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -369,7 +369,7 @@ func newMockRuleFlowBuilder(ctrl *gomock.Controller) *mocks.MockFlowBuilder {
 	ruleFlowBuilder.EXPECT().Action().Return(ruleAction).AnyTimes()
 	ruleFlow = mocks.NewMockFlow(ctrl)
 	ruleFlowBuilder.EXPECT().Done().Return(ruleFlow).AnyTimes()
-	ruleFlow.EXPECT().CopyToBuilder().Return(ruleFlowBuilder).AnyTimes()
+	ruleFlow.EXPECT().CopyToBuilder(gomock.Any()).Return(ruleFlowBuilder).AnyTimes()
 	return ruleFlowBuilder
 }
 

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -48,22 +48,27 @@ const (
 )
 
 const (
-	NxmFieldSrcMAC  = "NXM_OF_ETH_SRC"
-	NxmFieldDstMAC  = "NXM_OF_ETH_DST"
-	NxmFieldARPSha  = "NXM_NX_ARP_SHA"
-	NxmFieldARPTha  = "NXM_NX_ARP_THA"
-	NxmFieldARPSpa  = "NXM_OF_ARP_SPA"
-	NxmFieldARPTpa  = "NXM_OF_ARP_TPA"
-	NxmFieldCtLabel = "NXM_NX_CT_LABEL"
-	NxmFieldCtMark  = "NXM_NX_CT_MARK"
-	NxmFieldARPOp   = "NXM_OF_ARP_OP"
-	NxmFieldReg     = "NXM_NX_REG"
+	NxmFieldSrcMAC      = "NXM_OF_ETH_SRC"
+	NxmFieldDstMAC      = "NXM_OF_ETH_DST"
+	NxmFieldARPSha      = "NXM_NX_ARP_SHA"
+	NxmFieldARPTha      = "NXM_NX_ARP_THA"
+	NxmFieldARPSpa      = "NXM_OF_ARP_SPA"
+	NxmFieldARPTpa      = "NXM_OF_ARP_TPA"
+	NxmFieldCtLabel     = "NXM_NX_CT_LABEL"
+	NxmFieldCtMark      = "NXM_NX_CT_MARK"
+	NxmFieldARPOp       = "NXM_OF_ARP_OP"
+	NxmFieldReg         = "NXM_NX_REG"
+	NxmFieldTunMetadata = "NXM_NX_TUN_METADATA"
 )
 
 const (
 	AddMessage OFOperation = iota
 	ModifyMessage
 	DeleteMessage
+)
+
+const (
+	PacketInForTraceFlow = uint8(1)
 )
 
 // Bridge defines operations on an openflow bridge.
@@ -75,7 +80,7 @@ type Bridge interface {
 	DumpTableStatus() []TableStatus
 	// DumpFlows queries the Openflow entries from OFSwitch. The filter of the query is Openflow cookieID; the result is
 	// a map from flow cookieID to FlowStates.
-	DumpFlows(cookieID, cookieMask uint64) map[uint64]*FlowStates
+	DumpFlows(cookieID, cookieMask uint64) (map[uint64]*FlowStates, error)
 	// DeleteFlowsByCookie removes Openflow entries from OFSwitch. The removed Openflow entries use the specific CookieID.
 	DeleteFlowsByCookie(cookieID, cookieMask uint64) error
 	// AddFlowsInBundle syncs multiple Openflow entries in a single transaction. This operation could add new flows in
@@ -92,6 +97,17 @@ type Bridge interface {
 	Disconnect() error
 	// IsConnected returns the OFSwitch's connection status. The result is true if the OFSwitch is connected.
 	IsConnected() bool
+	// SubscribePacketIn registers a consumer to listen PacketIn message with a provided reason. When Bridge
+	// received a packetIn message with the specific reason, it sends the message to the consumer using the channel.
+	SubscribePacketIn(reason uint8, ch chan *ofctrl.PacketIn) error
+	// AddTLVMap adds a TLV mapping with OVS field tun_metadataX. The value loaded in tun_metadataX is transported
+	// by Geneve header with the specified <optClass, optType, optLength>. The value of OptLength is multiple of 4.
+	// The value loaded into tun_metadataX is shorter the length.
+	AddTLVMap(optClass uint16, optType uint8, optLength uint8, tunMetadataIndex uint16) error
+	// SendPacketOut sends a packetOut message to the OVS Bridge.
+	SendPacketOut(packetOut *ofctrl.PacketOut) error
+	// NewPacketOutBuilder returns a new PacketOutBuilder.
+	BuildPacketOut() PacketOutBuilder
 }
 
 // TableStatus represents the status of a specific flow table. The status is useful for debugging.
@@ -134,8 +150,9 @@ type OFEntry interface {
 type Flow interface {
 	OFEntry
 	MatchString() string
-	// CopyToBuilder returns a new FlowBuilder that copies the matches of the Flow, but does not copy the actions.
-	CopyToBuilder() FlowBuilder
+	// CopyToBuilder returns a new FlowBuilder that copies the matches of the Flow, but does not copy the actions. Reset
+	// the priority in the new FlowBuilder if it is provided.
+	CopyToBuilder(priority uint16) FlowBuilder
 }
 
 type Action interface {
@@ -166,6 +183,7 @@ type Action interface {
 	Conjunction(conjID uint32, clauseID uint8, nClause uint8) FlowBuilder
 	Group(id GroupIDType) FlowBuilder
 	Learn(id TableIDType, priority uint16, idleTimeout, hardTimeout uint16, cookieID uint64) LearnAction
+	SendToController(reason uint8) FlowBuilder
 }
 
 type FlowBuilder interface {
@@ -195,7 +213,10 @@ type FlowBuilder interface {
 	MatchTCPDstPort(port uint16) FlowBuilder
 	MatchUDPDstPort(port uint16) FlowBuilder
 	MatchSCTPDstPort(port uint16) FlowBuilder
+	MatchTunMetadata(index int, data uint32) FlowBuilder
 	Cookie(cookieID uint64) FlowBuilder
+	SetHardTimeout(timout uint16) FlowBuilder
+	SetIdleTimeout(timeout uint16) FlowBuilder
 	Action() Action
 	Done() Flow
 }
@@ -243,6 +264,29 @@ type CTAction interface {
 	// should be the same. portRange could be nil.
 	DNAT(ipRange *IPRange, portRange *PortRange) CTAction
 	CTDone() FlowBuilder
+}
+
+type PacketOutBuilder interface {
+	SetSrcMAC(mac net.HardwareAddr) PacketOutBuilder
+	SetDstMAC(mac net.HardwareAddr) PacketOutBuilder
+	SetSrcIP(ip net.IP) PacketOutBuilder
+	SetDstIP(ip net.IP) PacketOutBuilder
+	SetIPProtocol(protocol Protocol) PacketOutBuilder
+	SetTTL(ttl uint8) PacketOutBuilder
+	SetIPFlags(flags uint16) PacketOutBuilder
+	SetTCPsPort(port uint16) PacketOutBuilder
+	SetTCPdPort(port uint16) PacketOutBuilder
+	SetTCPFlags(flags uint8) PacketOutBuilder
+	SetUDPsPort(port uint16) PacketOutBuilder
+	SetUDPdPort(port uint16) PacketOutBuilder
+	SetICMPType(icmpType uint8) PacketOutBuilder
+	SetICMPCode(icmpCode uint8) PacketOutBuilder
+	SetICMPID(id uint16) PacketOutBuilder
+	SetICMPSequence(seq uint16) PacketOutBuilder
+	SetInport(inPort uint32) PacketOutBuilder
+	SetOutport(outport uint32) PacketOutBuilder
+	AddLoadAction(name string, data uint64, rng Range) PacketOutBuilder
+	Done() *ofctrl.PacketOut
 }
 
 type ctBase struct {

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -30,8 +30,7 @@ func (a *ofFlowAction) Output(port int) FlowBuilder {
 
 // OutputFieldRange is an action to output packets to the port located in the specified NXM field with rng.
 func (a *ofFlowAction) OutputFieldRange(name string, rng Range) FlowBuilder {
-	outputAction, _ := ofctrl.NewNXOutput(name, int(rng[0]), int(rng[1]))
-	a.builder.ofFlow.lastAction = outputAction
+	a.builder.OutputReg(name, int(rng[0]), int(rng[1]))
 	return a.builder
 }
 
@@ -215,20 +214,24 @@ func (a *ofFlowAction) SetTunnelDst(addr net.IP) FlowBuilder {
 
 // LoadARPOperation is an action to Load data to NXM_OF_ARP_OP field.
 func (a *ofFlowAction) LoadARPOperation(value uint16) FlowBuilder {
-	a.builder.ofFlow.LoadReg(NxmFieldARPOp, uint64(value), openflow13.NewNXRange(0, 15))
+	a.builder.ofFlow.LoadReg(NxmFieldARPOp, uint64(value), openflow13.NewNXRange(0, 15), false)
 	return a.builder
 }
 
 // LoadRange is an action to Load data to the target field at specified range.
 func (a *ofFlowAction) LoadRange(name string, value uint64, rng Range) FlowBuilder {
-	a.builder.ofFlow.LoadReg(name, value, rng.ToNXRange())
+	a.builder.ofFlow.LoadReg(name, value, rng.ToNXRange(), isTunMetadataField(name))
 	return a.builder
+}
+
+func isTunMetadataField(name string) bool {
+	return strings.HasPrefix(name, NxmFieldTunMetadata)
 }
 
 // LoadRegRange is an action to Load data to the target register at specified range.
 func (a *ofFlowAction) LoadRegRange(regID int, value uint32, rng Range) FlowBuilder {
 	name := fmt.Sprintf("%s%d", NxmFieldReg, regID)
-	a.builder.ofFlow.LoadReg(name, uint64(value), rng.ToNXRange())
+	a.builder.ofFlow.LoadReg(name, uint64(value), rng.ToNXRange(), false)
 	return a.builder
 }
 
@@ -242,7 +245,8 @@ func (a *ofFlowAction) Move(fromField, toField string) FlowBuilder {
 
 // MoveRange is an action to move data from "fromField" at "fromRange" to "toField" at "toRange".
 func (a *ofFlowAction) MoveRange(fromField, toField string, fromRange, toRange Range) FlowBuilder {
-	a.builder.ofFlow.MoveRegs(fromField, toField, fromRange.ToNXRange(), toRange.ToNXRange())
+	hasTunMetatadata := isTunMetadataField(fromField) || isTunMetadataField(toField)
+	a.builder.ofFlow.MoveRegs(fromField, toField, fromRange.ToNXRange(), toRange.ToNXRange(), hasTunMetatadata)
 	return a.builder
 }
 
@@ -285,6 +289,11 @@ func (a *ofFlowAction) Group(id GroupIDType) FlowBuilder {
 		ID:     uint32(id),
 	}
 	a.builder.ofFlow.lastAction = group
+	return a.builder
+}
+
+func (a *ofFlowAction) SendToController(reason uint8) FlowBuilder {
+	a.builder.ofFlow.Controller(reason)
 	return a.builder
 }
 

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -13,6 +13,27 @@ type ofFlowBuilder struct {
 	ofFlow
 }
 
+func (b *ofFlowBuilder) MatchTunMetadata(index int, data uint32) FlowBuilder {
+	rng := openflow13.NewNXRange(0, 31)
+	tm := &ofctrl.NXTunMetadata{
+		ID:    index,
+		Data:  data,
+		Range: rng,
+	}
+	b.ofFlow.Match.TunMetadatas = append(b.ofFlow.Match.TunMetadatas, tm)
+	return b
+}
+
+func (b *ofFlowBuilder) SetHardTimeout(timout uint16) FlowBuilder {
+	b.ofFlow.HardTimeout = timout
+	return b
+}
+
+func (b *ofFlowBuilder) SetIdleTimeout(timeout uint16) FlowBuilder {
+	b.ofFlow.IdleTimeout = timeout
+	return b
+}
+
 func (b *ofFlowBuilder) Done() Flow {
 	if b.ctStates != nil {
 		b.Flow.Match.CtStates = b.ctStates

--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -113,8 +113,8 @@ func (f *ofFlow) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMess
 // CopyToBuilder returns a new FlowBuilder that copies the table, protocols,
 // matches, and CookieID of the Flow, but does not copy the actions, lastAction,
 // and other private status fields of the ofctrl.Flow, e.g. "realized" and
-// "isInstalled".
-func (f *ofFlow) CopyToBuilder() FlowBuilder {
+// "isInstalled". Reset the priority in the new FlowBuilder if it is provided.
+func (f *ofFlow) CopyToBuilder(priority uint16) FlowBuilder {
 	newFlow := ofFlow{
 		table: f.table,
 		Flow: ofctrl.Flow{
@@ -125,6 +125,9 @@ func (f *ofFlow) CopyToBuilder() FlowBuilder {
 		},
 		matchers: f.matchers,
 		protocol: f.protocol,
+	}
+	if priority > 0 {
+		newFlow.Flow.Match.Priority = priority
 	}
 	return &ofFlowBuilder{newFlow}
 }

--- a/pkg/ovs/openflow/ofctrl_flow_test.go
+++ b/pkg/ovs/openflow/ofctrl_flow_test.go
@@ -22,7 +22,10 @@ func TestCopyToBuilder(t *testing.T) {
 		LoadToMark(uint32(12345)).
 		MoveToLabel(NxmFieldSrcMAC, &Range{0, 47}, &Range{0, 47}).CTDone().
 		Done()
-	newFlow := oriFlow.CopyToBuilder()
+	newFlow := oriFlow.CopyToBuilder(0)
 	assert.Equal(t, oriFlow.MatchString(), newFlow.Done().MatchString())
 	assert.Equal(t, oriFlow.(*ofFlow).Match, newFlow.Done().(*ofFlow).Match)
+	newPriority := uint16(200)
+	newFlow2 := oriFlow.CopyToBuilder(newPriority)
+	assert.Equal(t, newPriority, newFlow2.Done().(*ofFlow).Match.Priority)
 }

--- a/pkg/ovs/openflow/ofctrl_packetout.go
+++ b/pkg/ovs/openflow/ofctrl_packetout.go
@@ -1,0 +1,232 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"net"
+
+	"github.com/contiv/libOpenflow/protocol"
+	"github.com/contiv/ofnet/ofctrl"
+)
+
+type ofPacketOutBuilder struct {
+	pktOut  *ofctrl.PacketOut
+	icmpID  *uint16
+	icmpSeq *uint16
+}
+
+// SetSrcMAC sets the packet's source MAC with the provided value.
+func (b *ofPacketOutBuilder) SetSrcMAC(mac net.HardwareAddr) PacketOutBuilder {
+	b.pktOut.SrcMAC = mac
+	return b
+}
+
+// SetDstMAC sets the packet's destination MAC with the provided value.
+func (b *ofPacketOutBuilder) SetDstMAC(mac net.HardwareAddr) PacketOutBuilder {
+	b.pktOut.DstMAC = mac
+	return b
+}
+
+// SetSrcIP sets the packet's source IP with the provided value.
+func (b *ofPacketOutBuilder) SetSrcIP(ip net.IP) PacketOutBuilder {
+	if b.pktOut.IPHeader == nil {
+		b.pktOut.IPHeader = new(protocol.IPv4)
+	}
+	b.pktOut.IPHeader.NWSrc = ip
+	return b
+}
+
+// SetDstIP sets the packet's destination IP with the provided value.
+func (b *ofPacketOutBuilder) SetDstIP(ip net.IP) PacketOutBuilder {
+	if b.pktOut.IPHeader == nil {
+		b.pktOut.IPHeader = new(protocol.IPv4)
+	}
+	b.pktOut.IPHeader.NWDst = ip
+	return b
+}
+
+// SetIPProtocol sets IP protocol in the packet's IP header.
+func (b *ofPacketOutBuilder) SetIPProtocol(proto Protocol) PacketOutBuilder {
+	if b.pktOut.IPHeader == nil {
+		b.pktOut.IPHeader = new(protocol.IPv4)
+	}
+	switch proto {
+	case ProtocolTCP:
+		b.pktOut.IPHeader.Protocol = protocol.Type_TCP
+	case ProtocolUDP:
+		b.pktOut.IPHeader.Protocol = protocol.Type_UDP
+	case ProtocolSCTP:
+		b.pktOut.IPHeader.Protocol = 0x84
+	case ProtocolICMP:
+		b.pktOut.IPHeader.Protocol = protocol.Type_ICMP
+	default:
+		b.pktOut.IPHeader.Protocol = 0xff
+	}
+	return b
+}
+
+// SetTTL sets TTL in the packet's IP header.
+func (b *ofPacketOutBuilder) SetTTL(ttl uint8) PacketOutBuilder {
+	if b.pktOut.IPHeader == nil {
+		b.pktOut.IPHeader = new(protocol.IPv4)
+	}
+	b.pktOut.IPHeader.TTL = ttl
+	return b
+}
+
+// SetIPFlags sets flags in the packet's IP header.
+func (b *ofPacketOutBuilder) SetIPFlags(flags uint16) PacketOutBuilder {
+	if b.pktOut.IPHeader == nil {
+		b.pktOut.IPHeader = new(protocol.IPv4)
+	}
+	b.pktOut.IPHeader.Flags = flags
+	return b
+}
+
+// SetTCPsPort sets the source port in the packet's TCP header.
+func (b *ofPacketOutBuilder) SetTCPsPort(port uint16) PacketOutBuilder {
+	if b.pktOut.TCPHeader == nil {
+		b.pktOut.TCPHeader = new(protocol.TCP)
+	}
+	b.pktOut.TCPHeader.PortSrc = port
+	return b
+}
+
+// SetTCPdPort sets the destination port in the packet's TCP header.
+func (b *ofPacketOutBuilder) SetTCPdPort(port uint16) PacketOutBuilder {
+	if b.pktOut.TCPHeader == nil {
+		b.pktOut.TCPHeader = new(protocol.TCP)
+	}
+	b.pktOut.TCPHeader.PortDst = port
+	return b
+}
+
+// SetTCPFlags sets the flags in the packet's TCP header.
+func (b *ofPacketOutBuilder) SetTCPFlags(flags uint8) PacketOutBuilder {
+	if b.pktOut.TCPHeader == nil {
+		b.pktOut.TCPHeader = new(protocol.TCP)
+	}
+	b.pktOut.TCPHeader.Code = flags
+	return b
+}
+
+// SetUDPsPort sets the source port in the packet's UDP header.
+func (b *ofPacketOutBuilder) SetUDPsPort(port uint16) PacketOutBuilder {
+	if b.pktOut.UDPHeader == nil {
+		b.pktOut.UDPHeader = new(protocol.UDP)
+	}
+	b.pktOut.UDPHeader.PortSrc = port
+	return b
+}
+
+// SetUDPdPort sets the destination port in the packet's UDP header.
+func (b *ofPacketOutBuilder) SetUDPdPort(port uint16) PacketOutBuilder {
+	if b.pktOut.UDPHeader == nil {
+		b.pktOut.UDPHeader = new(protocol.UDP)
+	}
+	b.pktOut.UDPHeader.PortDst = port
+	return b
+}
+
+// SetICMPType sets the type in the packet's ICMP header.
+func (b *ofPacketOutBuilder) SetICMPType(icmpType uint8) PacketOutBuilder {
+	if b.pktOut.ICMPHeader == nil {
+		b.pktOut.ICMPHeader = new(protocol.ICMP)
+	}
+	b.pktOut.ICMPHeader.Type = icmpType
+	return b
+}
+
+// SetICMPCode sets the code in the packet's ICMP header.
+func (b *ofPacketOutBuilder) SetICMPCode(icmpCode uint8) PacketOutBuilder {
+	if b.pktOut.ICMPHeader == nil {
+		b.pktOut.ICMPHeader = new(protocol.ICMP)
+	}
+	b.pktOut.ICMPHeader.Code = icmpCode
+	return b
+}
+
+// SetICMs sets the identifier in the packet's ICMP header.
+func (b *ofPacketOutBuilder) SetICMPID(id uint16) PacketOutBuilder {
+	if b.pktOut.ICMPHeader == nil {
+		b.pktOut.ICMPHeader = new(protocol.ICMP)
+	}
+	b.icmpID = &id
+	return b
+}
+
+//SetICMPSequence sets the sequence number in the packet's ICMP header.
+func (b *ofPacketOutBuilder) SetICMPSequence(seq uint16) PacketOutBuilder {
+	if b.pktOut.ICMPHeader == nil {
+		b.pktOut.ICMPHeader = new(protocol.ICMP)
+	}
+	b.icmpSeq = &seq
+	return b
+}
+
+// SetInport sets the in_port field of the packetOut message.
+func (b *ofPacketOutBuilder) SetInport(inPort uint32) PacketOutBuilder {
+	b.pktOut.InPort = inPort
+	return b
+}
+
+// SetOutport sets the output port of the packetOut message. If the message is expected to go through OVS pipeline
+// from table0, use openflow13.P_TABLE, which is also the default value.
+func (b *ofPacketOutBuilder) SetOutport(outport uint32) PacketOutBuilder {
+	b.pktOut.OutPort = outport
+	return b
+}
+
+// AddLoadAction loads the data to the target field at specified range when the packet is received by OVS Switch.
+func (b *ofPacketOutBuilder) AddLoadAction(name string, data uint64, rng Range) PacketOutBuilder {
+	act, _ := ofctrl.NewNXLoadAction(name, data, rng.ToNXRange())
+	b.pktOut.Actions = append(b.pktOut.Actions, act)
+	return b
+}
+
+func (b *ofPacketOutBuilder) Done() *ofctrl.PacketOut {
+	if b.pktOut.ICMPHeader != nil {
+		b.setICMPData()
+		b.pktOut.IPHeader.Length = 20 + b.pktOut.ICMPHeader.Len()
+	} else if b.pktOut.TCPHeader != nil {
+		b.pktOut.TCPHeader.HdrLen = 5
+		b.pktOut.TCPHeader.SeqNum = rand.Uint32()
+		b.pktOut.TCPHeader.AckNum = rand.Uint32()
+		b.pktOut.IPHeader.Length = 20 + b.pktOut.TCPHeader.Len()
+	} else if b.pktOut.UDPHeader != nil {
+		b.pktOut.IPHeader.Length = 20 + b.pktOut.UDPHeader.Len()
+	}
+	b.pktOut.IPHeader.Id = uint16(rand.Uint32())
+	// Set IP version in the IP Header.
+	if b.pktOut.IPHeader.NWSrc.To16() != nil {
+		b.pktOut.IPHeader.Version = 0x6
+	} else {
+		b.pktOut.IPHeader.Version = 0x4
+	}
+	return b.pktOut
+}
+
+func (b *ofPacketOutBuilder) setICMPData() {
+	data := make([]byte, 4)
+	if b.icmpID != nil {
+		binary.BigEndian.PutUint16(data, *b.icmpID)
+	}
+	if b.icmpSeq != nil {
+		binary.BigEndian.PutUint16(data[2:], *b.icmpSeq)
+	}
+	b.pktOut.ICMPHeader.Data = data
+}

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -78,6 +78,34 @@ func (mr *MockBridgeMockRecorder) AddOFEntriesInBundle(arg0, arg1, arg2 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOFEntriesInBundle", reflect.TypeOf((*MockBridge)(nil).AddOFEntriesInBundle), arg0, arg1, arg2)
 }
 
+// AddTLVMap mocks base method
+func (m *MockBridge) AddTLVMap(arg0 uint16, arg1, arg2 byte, arg3 uint16) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddTLVMap", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddTLVMap indicates an expected call of AddTLVMap
+func (mr *MockBridgeMockRecorder) AddTLVMap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTLVMap", reflect.TypeOf((*MockBridge)(nil).AddTLVMap), arg0, arg1, arg2, arg3)
+}
+
+// BuildPacketOut mocks base method
+func (m *MockBridge) BuildPacketOut() openflow.PacketOutBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BuildPacketOut")
+	ret0, _ := ret[0].(openflow.PacketOutBuilder)
+	return ret0
+}
+
+// BuildPacketOut indicates an expected call of BuildPacketOut
+func (mr *MockBridgeMockRecorder) BuildPacketOut() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildPacketOut", reflect.TypeOf((*MockBridge)(nil).BuildPacketOut))
+}
+
 // Connect mocks base method
 func (m *MockBridge) Connect(arg0 int, arg1 chan struct{}) error {
 	m.ctrl.T.Helper()
@@ -177,11 +205,12 @@ func (mr *MockBridgeMockRecorder) Disconnect() *gomock.Call {
 }
 
 // DumpFlows mocks base method
-func (m *MockBridge) DumpFlows(arg0, arg1 uint64) map[uint64]*openflow.FlowStates {
+func (m *MockBridge) DumpFlows(arg0, arg1 uint64) (map[uint64]*openflow.FlowStates, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DumpFlows", arg0, arg1)
 	ret0, _ := ret[0].(map[uint64]*openflow.FlowStates)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DumpFlows indicates an expected call of DumpFlows
@@ -216,6 +245,34 @@ func (m *MockBridge) IsConnected() bool {
 func (mr *MockBridgeMockRecorder) IsConnected() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConnected", reflect.TypeOf((*MockBridge)(nil).IsConnected))
+}
+
+// SendPacketOut mocks base method
+func (m *MockBridge) SendPacketOut(arg0 *ofctrl.PacketOut) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendPacketOut", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendPacketOut indicates an expected call of SendPacketOut
+func (mr *MockBridgeMockRecorder) SendPacketOut(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendPacketOut", reflect.TypeOf((*MockBridge)(nil).SendPacketOut), arg0)
+}
+
+// SubscribePacketIn mocks base method
+func (m *MockBridge) SubscribePacketIn(arg0 byte, arg1 chan *ofctrl.PacketIn) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubscribePacketIn", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SubscribePacketIn indicates an expected call of SubscribePacketIn
+func (mr *MockBridgeMockRecorder) SubscribePacketIn(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribePacketIn", reflect.TypeOf((*MockBridge)(nil).SubscribePacketIn), arg0, arg1)
 }
 
 // MockTable is a mock of Table interface
@@ -349,17 +406,17 @@ func (mr *MockFlowMockRecorder) Add() *gomock.Call {
 }
 
 // CopyToBuilder mocks base method
-func (m *MockFlow) CopyToBuilder() openflow.FlowBuilder {
+func (m *MockFlow) CopyToBuilder(arg0 uint16) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CopyToBuilder")
+	ret := m.ctrl.Call(m, "CopyToBuilder", arg0)
 	ret0, _ := ret[0].(openflow.FlowBuilder)
 	return ret0
 }
 
 // CopyToBuilder indicates an expected call of CopyToBuilder
-func (mr *MockFlowMockRecorder) CopyToBuilder() *gomock.Call {
+func (mr *MockFlowMockRecorder) CopyToBuilder(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyToBuilder", reflect.TypeOf((*MockFlow)(nil).CopyToBuilder))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyToBuilder", reflect.TypeOf((*MockFlow)(nil).CopyToBuilder), arg0)
 }
 
 // Delete mocks base method
@@ -732,6 +789,20 @@ func (m *MockAction) ResubmitToTable(arg0 openflow.TableIDType) openflow.FlowBui
 func (mr *MockActionMockRecorder) ResubmitToTable(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResubmitToTable", reflect.TypeOf((*MockAction)(nil).ResubmitToTable), arg0)
+}
+
+// SendToController mocks base method
+func (m *MockAction) SendToController(arg0 byte) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendToController", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// SendToController indicates an expected call of SendToController
+func (mr *MockActionMockRecorder) SendToController(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendToController", reflect.TypeOf((*MockAction)(nil).SendToController), arg0)
 }
 
 // SetARPSha mocks base method
@@ -1275,6 +1346,20 @@ func (mr *MockFlowBuilderMockRecorder) MatchTCPDstPort(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchTCPDstPort", reflect.TypeOf((*MockFlowBuilder)(nil).MatchTCPDstPort), arg0)
 }
 
+// MatchTunMetadata mocks base method
+func (m *MockFlowBuilder) MatchTunMetadata(arg0 int, arg1 uint32) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchTunMetadata", arg0, arg1)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchTunMetadata indicates an expected call of MatchTunMetadata
+func (mr *MockFlowBuilderMockRecorder) MatchTunMetadata(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchTunMetadata", reflect.TypeOf((*MockFlowBuilder)(nil).MatchTunMetadata), arg0, arg1)
+}
+
 // MatchUDPDstPort mocks base method
 func (m *MockFlowBuilder) MatchUDPDstPort(arg0 uint16) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
@@ -1287,4 +1372,32 @@ func (m *MockFlowBuilder) MatchUDPDstPort(arg0 uint16) openflow.FlowBuilder {
 func (mr *MockFlowBuilderMockRecorder) MatchUDPDstPort(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchUDPDstPort", reflect.TypeOf((*MockFlowBuilder)(nil).MatchUDPDstPort), arg0)
+}
+
+// SetHardTimeout mocks base method
+func (m *MockFlowBuilder) SetHardTimeout(arg0 uint16) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetHardTimeout", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// SetHardTimeout indicates an expected call of SetHardTimeout
+func (mr *MockFlowBuilderMockRecorder) SetHardTimeout(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHardTimeout", reflect.TypeOf((*MockFlowBuilder)(nil).SetHardTimeout), arg0)
+}
+
+// SetIdleTimeout mocks base method
+func (m *MockFlowBuilder) SetIdleTimeout(arg0 uint16) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetIdleTimeout", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// SetIdleTimeout indicates an expected call of SetIdleTimeout
+func (mr *MockFlowBuilderMockRecorder) SetIdleTimeout(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIdleTimeout", reflect.TypeOf((*MockFlowBuilder)(nil).SetIdleTimeout), arg0)
 }

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/contiv/ofnet/ofctrl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -207,7 +208,7 @@ func TestOFctrlFlow(t *testing.T) {
 
 		// Test: DumpFlows
 		dumpCookieID, dumpCookieMask := getCookieIDMask()
-		flowStates := bridge.DumpFlows(dumpCookieID, dumpCookieMask)
+		flowStates, _ := bridge.DumpFlows(dumpCookieID, dumpCookieMask)
 		if len(flowStates) != len(flowList) {
 			t.Errorf("Flow count in dump result is incorrect")
 		}
@@ -543,6 +544,162 @@ func TestBundleWithGroupAndFlow(t *testing.T) {
 	require.Nil(t, err)
 	CheckFlowExists(t, ofctlClient, uint8(table.GetID()), false, expectedFlows)
 	CheckGroupExists(t, ofctlClient, groupID, "select", expectedGroupBuckets, false)
+}
+
+func TestPacketOutIn(t *testing.T) {
+	br := "br09"
+	err := PrepareOVSBridge(br)
+	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
+	defer DeleteOVSBridge(br)
+
+	bridge := binding.NewOFBridge(br)
+	table0 := bridge.CreateTable(0, 1, binding.TableMissActionNext)
+	table1 := bridge.CreateTable(1, 2, binding.TableMissActionNext)
+
+	err = bridge.Connect(maxRetry, make(chan struct{}))
+	require.Nil(t, err, "Failed to start OFService")
+	defer bridge.Disconnect()
+
+	reason := uint8(1)
+	pktCh := make(chan *ofctrl.PacketIn)
+	err = bridge.SubscribePacketIn(reason, pktCh)
+	require.Nil(t, err)
+
+	srcMAC, _ := net.ParseMAC("11:11:11:11:11:11")
+	dstcMAC, _ := net.ParseMAC("11:11:11:11:11:22")
+	srcIP := net.ParseIP("1.1.1.2")
+	dstIP := net.ParseIP("2.2.2.2")
+	tunDst := net.ParseIP("10.10.10.2")
+	srcPort := uint16(10001)
+	dstPort := uint16(8080)
+	reg2Data := uint32(0x1234)
+	reg2Range := binding.Range{0, 15}
+	reg3Data := uint32(0x1234)
+	reg3Range := binding.Range{0, 31}
+	stopCh := make(chan struct{})
+
+	go func() {
+		pktIn := <-pktCh
+		matchers := pktIn.GetMatches()
+
+		reg2Match := matchers.GetMatchByName("NXM_NX_REG2")
+		assert.NotNil(t, reg2Match)
+		reg2Value := reg2Match.GetValue()
+		assert.NotNil(t, reg2Value)
+		value2, ok2 := reg2Value.(*ofctrl.NXRegister)
+		assert.True(t, ok2)
+		assert.Equal(t, reg2Data, ofctrl.GetUint32ValueWithRange(value2.Data, reg2Range.ToNXRange()))
+
+		reg3Match := matchers.GetMatchByName("NXM_NX_REG3")
+		assert.NotNil(t, reg3Match)
+		reg3Value := reg3Match.GetValue()
+		assert.NotNil(t, reg3Value)
+		value3, ok3 := reg3Value.(*ofctrl.NXRegister)
+		assert.True(t, ok3)
+		assert.Equal(t, reg3Data, value3.Data)
+
+		tunDstMatch := matchers.GetMatchByName("NXM_NX_TUN_IPV4_DST")
+		assert.NotNil(t, tunDstMatch)
+		tunDstValue := tunDstMatch.GetValue()
+		assert.NotNil(t, tunDstValue)
+		value4, ok4 := tunDstValue.(net.IP)
+		assert.True(t, ok4)
+		assert.Equal(t, tunDst, value4)
+
+		close(stopCh)
+	}()
+
+	pktBuilder := bridge.BuildPacketOut()
+	pkt := pktBuilder.SetSrcMAC(srcMAC).SetDstMAC(dstcMAC).
+		SetDstIP(dstIP).SetSrcIP(srcIP).SetIPProtocol(binding.ProtocolTCP).
+		SetTCPsPort(srcPort).SetTCPdPort(dstPort).
+		AddLoadAction("NXM_NX_REG0", uint64(0x1), binding.Range{18, 18}).
+		Done()
+	require.Nil(t, err)
+	flow0 := table0.BuildFlow(100).
+		MatchSrcMAC(srcMAC).MatchDstMAC(dstcMAC).
+		MatchSrcIP(srcIP).MatchDstIP(dstIP).MatchProtocol(binding.ProtocolTCP).
+		MatchRegRange(0, 0x1, binding.Range{18, 18}).
+		Action().LoadRegRange(2, reg2Data, reg2Range).
+		Action().LoadRegRange(3, reg3Data, reg3Range).
+		Action().SetTunnelDst(tunDst).
+		Action().ResubmitToTable(table0.GetNext()).
+		Done()
+	flow1 := table1.BuildFlow(100).
+		MatchSrcMAC(srcMAC).MatchDstMAC(dstcMAC).
+		MatchSrcIP(srcIP).MatchDstIP(dstIP).MatchProtocol(binding.ProtocolTCP).
+		MatchRegRange(0, 0x1, binding.Range{18, 18}).
+		Action().SendToController(0x1).
+		Done()
+	err = bridge.AddFlowsInBundle([]binding.Flow{flow0, flow1}, nil, nil)
+	require.Nil(t, err)
+	err = bridge.SendPacketOut(pkt)
+	<-stopCh
+}
+
+func TestTLVMap(t *testing.T) {
+	br := "br10"
+	err := PrepareOVSBridge(br)
+	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
+	//defer DeleteOVSBridge(br)
+
+	bridge := binding.NewOFBridge(br)
+	table := bridge.CreateTable(0, 1, binding.TableMissActionNext)
+
+	err = bridge.Connect(maxRetry, make(chan struct{}))
+	require.Nil(t, err, "Failed to start OFService")
+	defer bridge.Disconnect()
+
+	err = bridge.AddTLVMap(0xffff, 0x1, 4, 0)
+	require.Nil(t, err)
+	time.Sleep(1 * time.Second)
+	flow1 := table.BuildFlow(100).
+		MatchProtocol(binding.ProtocolIP).MatchTunMetadata(0, 0x1234).
+		Action().ResubmitToTable(table.GetNext()).
+		Done()
+	err = bridge.AddFlowsInBundle([]binding.Flow{flow1}, nil, nil)
+	require.Nil(t, err)
+	expectedFlows := []*ExpectFlow{
+		{
+			MatchStr: "priority=100,ip,tun_metadata0=0x1234",
+			ActStr:   fmt.Sprintf("resubmit(,%d)", table.GetNext()),
+		},
+	}
+	ofctlClient := ofctl.NewClient(br)
+	CheckFlowExists(t, ofctlClient, uint8(table.GetID()), true, expectedFlows)
+}
+
+func TestMoveTunMetadata(t *testing.T) {
+	br := "br11"
+	err := PrepareOVSBridge(br)
+	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
+	//defer DeleteOVSBridge(br)
+
+	bridge := binding.NewOFBridge(br)
+	table := bridge.CreateTable(0, 1, binding.TableMissActionNext)
+
+	err = bridge.Connect(maxRetry, make(chan struct{}))
+	require.Nil(t, err, "Failed to start OFService")
+	defer bridge.Disconnect()
+
+	err = bridge.AddTLVMap(0xffff, 0x1, 4, 0)
+	require.Nil(t, err)
+	time.Sleep(1 * time.Second)
+	flow1 := table.BuildFlow(100).
+		MatchProtocol(binding.ProtocolIP).MatchTunMetadata(0, 0x1234).
+		Action().MoveRange("NXM_NX_TUN_METADATA0", "NXM_NX_REG0", binding.Range{28, 31}, binding.Range{28, 31}).
+		Action().ResubmitToTable(table.GetNext()).
+		Done()
+	err = bridge.AddFlowsInBundle([]binding.Flow{flow1}, nil, nil)
+	require.Nil(t, err)
+	expectedFlows := []*ExpectFlow{
+		{
+			MatchStr: "priority=100,ip,tun_metadata0=0x1234",
+			ActStr:   fmt.Sprintf("move:NXM_NX_TUN_METADATA0[28..31]->NXM_NX_REG0[28..31],resubmit(,%d)", table.GetNext()),
+		},
+	}
+	ofctlClient := ofctl.NewClient(br)
+	CheckFlowExists(t, ofctlClient, uint8(table.GetID()), true, expectedFlows)
 }
 
 func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {


### PR DESCRIPTION
…rol interface

1. Add support for PacketIn and PacketOut message. The consumer should register
   a reason when subscribing PacketIn message.
2. Add support for Geneve Header TLV config. The consumer should add TLV map first,
   and load customized data into the registered tunnel_metadata.